### PR TITLE
Add worker metrics ASGI endpoint

### DIFF
--- a/apps/worker/metrics_server.py
+++ b/apps/worker/metrics_server.py
@@ -1,0 +1,88 @@
+"""Lightweight ASGI app that exposes worker Prometheus metrics."""
+from __future__ import annotations
+
+import base64
+from typing import List, Sequence, Tuple
+
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+from apps.worker.config import settings
+
+HeaderList = Sequence[Tuple[bytes, bytes]]
+
+
+def _parse_basic_auth(headers: HeaderList) -> str | None:
+    """Return the decoded basic auth payload if provided."""
+
+    for name, value in headers:
+        if name.lower() == b"authorization" and value.startswith(b"Basic "):
+            encoded = value.split(b" ", 1)[1]
+            try:
+                return base64.b64decode(encoded).decode("utf-8")
+            except (ValueError, UnicodeDecodeError):  # pragma: no cover - defensive
+                return None
+    return None
+
+
+def handle_metrics_request(
+    method: str,
+    path: str,
+    headers: HeaderList,
+) -> Tuple[int, List[Tuple[bytes, bytes]], bytes]:
+    """Generate a Prometheus exposition response.
+
+    This helper is kept separate from the ASGI app so that it can be unit tested
+    without standing up an HTTP server.
+    """
+
+    method = method.upper()
+    if path.rstrip("/") != "/metrics":
+        return 404, [(b"content-type", b"text/plain; charset=utf-8")], b"Not Found"
+
+    if method not in {"GET", "HEAD"}:
+        return 405, [(b"allow", b"GET, HEAD")], b""
+
+    if settings.metrics_auth:
+        supplied = _parse_basic_auth(headers)
+        if supplied != settings.metrics_auth:
+            return (
+                401,
+                [
+                    (b"www-authenticate", b"Basic"),
+                    (b"content-type", b"text/plain; charset=utf-8"),
+                ],
+                b"Unauthorized",
+            )
+
+    payload = generate_latest()
+    response_headers: List[Tuple[bytes, bytes]] = [
+        (b"content-type", CONTENT_TYPE_LATEST.encode("ascii")),
+        (b"content-length", str(len(payload)).encode("ascii")),
+    ]
+    body = payload if method == "GET" else b""
+    return 200, response_headers, body
+
+
+async def app(scope, receive, send):  # type: ignore[override]
+    """Minimal ASGI application that serves metrics."""
+
+    if scope["type"] != "http":  # pragma: no cover - ASGI protocol guard
+        raise RuntimeError("Metrics app only handles HTTP requests")
+
+    status, headers, body = handle_metrics_request(
+        scope.get("method", "GET"),
+        scope.get("path", "/"),
+        scope.get("headers", ()),
+    )
+
+    await send(
+        {
+            "type": "http.response.start",
+            "status": status,
+            "headers": list(headers),
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+__all__ = ["app", "handle_metrics_request"]

--- a/apps/worker/tests/test_metrics_server.py
+++ b/apps/worker/tests/test_metrics_server.py
@@ -1,0 +1,70 @@
+import base64
+
+import pytest
+
+from prometheus_client import CONTENT_TYPE_LATEST
+
+from apps.worker.config import settings
+from apps.worker.metrics_server import handle_metrics_request
+
+
+def _header_dict(headers):
+    return {name: value for name, value in headers}
+
+
+def test_metrics_request_succeeds_without_auth(monkeypatch):
+    original = settings.metrics_auth
+    settings.metrics_auth = None
+    try:
+        status, headers, body = handle_metrics_request("GET", "/metrics", [])
+    finally:
+        settings.metrics_auth = original
+
+    assert status == 200
+    headers_dict = _header_dict(headers)
+    assert headers_dict[b"content-type"] == CONTENT_TYPE_LATEST.encode("ascii")
+    assert body.startswith(b"# HELP")
+
+
+def test_metrics_request_requires_basic_auth(monkeypatch):
+    original = settings.metrics_auth
+    settings.metrics_auth = "user:pass"
+    try:
+        status, headers, body = handle_metrics_request("GET", "/metrics", [])
+        assert status == 401
+        headers_dict = _header_dict(headers)
+        assert headers_dict[b"www-authenticate"] == b"Basic"
+
+        token = base64.b64encode(b"user:pass").decode("ascii")
+        status, headers, body = handle_metrics_request(
+            "GET",
+            "/metrics",
+            [(b"authorization", f"Basic {token}".encode("ascii"))],
+        )
+    finally:
+        settings.metrics_auth = original
+
+    assert status == 200
+    assert body.startswith(b"# HELP")
+
+
+@pytest.mark.parametrize(
+    "method, expected_status",
+    [
+        ("GET", 200),
+        ("HEAD", 200),
+        ("POST", 405),
+    ],
+)
+def test_metrics_methods(method, expected_status):
+    status, headers, body = handle_metrics_request(method, "/metrics", [])
+    assert status == expected_status
+
+    if method == "HEAD" and status == 200:
+        assert body == b""
+
+
+def test_metrics_path_not_found():
+    status, headers, body = handle_metrics_request("GET", "/not-metrics", [])
+    assert status == 404
+    assert body == b"Not Found"

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -43,6 +43,15 @@ Both API and worker expose Prometheus metrics at `/metrics`. Configure `METRICS_
 - `ledger_lift_job_duration_seconds`
 - `ledger_lift_queue_depth`
 
+To run the worker metrics endpoint locally you can serve the lightweight ASGI app with uvicorn:
+
+```bash
+cd apps/worker
+uvicorn apps.worker.metrics_server:app --host 0.0.0.0 --port 8000
+```
+
+Prometheus scrapes the worker on the configured port (default `8000` in the provided docker compose file).
+
 ## Emergency Stop
 
 Create the Redis key defined by `EMERGENCY_STOP_KEY` to prevent new work from being accepted. Workers check the key between pipeline stages and exit gracefully when set.


### PR DESCRIPTION
## Summary
- add a lightweight ASGI application that serves the worker Prometheus metrics with optional basic authentication
- cover the metrics handler with unit tests for auth, HTTP verbs, and routing behaviour
- document how to run the worker metrics endpoint for local monitoring

## Testing
- PYTHONPATH=/workspace/Ledger.Lift pytest apps/worker/tests/test_metrics_server.py

------
https://chatgpt.com/codex/tasks/task_e_68dc44133cd8832ba89ab234323cf546