### PR TITLE
fix(upload): T0 + T0.1 hardening (surgical) — deploy config + ETag + hashing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,20 @@
-NEXT_PUBLIC_API_URL=
-ALLOWED_ORIGINS=
+# Shared/server configuration
+ALLOWED_ORIGINS=<https://ledgerlift1.netlify.app, http://localhost:3000>
 PDF_MAX_MB=100
 NEXT_PUBLIC_PDF_MAX_MB=100
 PRESIGN_TTL=900
-REGION=
-R2_S3_ENDPOINT=
-R2_BUCKET=
-R2_ACCESS_KEY_ID=
-R2_SECRET_ACCESS_KEY=
+REGION=<r2-or-aws-region>
+R2_S3_ENDPOINT=<accountid>.r2.cloudflarestorage.com
+R2_BUCKET=<bucket>
+R2_ACCESS_KEY_ID=***
+R2_SECRET_ACCESS_KEY=***
 R2_MULTIPART_THRESHOLD_MB=50
+
+# Frontend configuration
+NEXT_PUBLIC_API_URL=<https://ledgerlift1.netlify.app or http://localhost:8888>
+NODE_ENV=development
+
+# Feature flags
 FEATURES_T1_QUEUE=false
 FEATURES_T2_OCR=false
 FEATURES_T3_AUDIT=false
-NODE_ENV=development

--- a/apps/web/src/components/UploadPanel.tsx
+++ b/apps/web/src/components/UploadPanel.tsx
@@ -379,6 +379,8 @@ export async function uploadPartWithRetry(
   partNumber: number,
   maxRetries = 3
 ): Promise<string> {
+  const normalizeEtag = (etag: string) => etag.replace(/^"|"$/g, '');
+
   for (let attempt = 0; attempt < maxRetries; attempt += 1) {
     try {
       const response = await fetch(url, {
@@ -393,7 +395,7 @@ export async function uploadPartWithRetry(
           throw new Error('Missing ETag');
         }
 
-        return etag;
+        return normalizeEtag(etag);
       }
 
       if (response.status < 500) {

--- a/docs/deploy/netlify.md
+++ b/docs/deploy/netlify.md
@@ -1,0 +1,48 @@
+# Netlify Deployment Runbook
+
+This checklist hardens the upload pipeline for Ledger Lift. Complete each step when deploying to Netlify so production single PUT and multipart uploads succeed.
+
+## 1. Configure environment variables
+
+Set the following variables for both **Site environment** and **Functions** contexts. Values must match the placeholders from `.env.example`.
+
+| Variable | Notes |
+| --- | --- |
+| `ALLOWED_ORIGINS` | Comma-separated list including `https://ledgerlift1.netlify.app` and local development origins like `http://localhost:3000`. |
+| `PDF_MAX_MB` / `NEXT_PUBLIC_PDF_MAX_MB` | Keep these in sync (default `100`). Controls validation on both the API and client. |
+| `PRESIGN_TTL` | Seconds that presigned URLs remain valid (default `900`). |
+| `NEXT_PUBLIC_API_URL` | Base URL for client requests (`https://ledgerlift1.netlify.app` in production, `http://localhost:8888` locally). |
+| `REGION` | R2 or S3 region identifier. |
+| `R2_S3_ENDPOINT` | Cloudflare R2 endpoint in the form `<accountid>.r2.cloudflarestorage.com`. |
+| `R2_BUCKET` | Target bucket for uploads. |
+| `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | Credentials with permission to perform multipart uploads. |
+| `R2_MULTIPART_THRESHOLD_MB` | Files larger than this use multipart (default `50`). |
+| `NODE_ENV` | `production` on Netlify. |
+
+> **Tip:** Keep the client and functions values aligned—mismatched thresholds or origins lead to preflight or upload failures.
+
+## 2. Confirm build & functions configuration
+
+- `netlify.toml` already proxies `/api/*` to `/.netlify/functions/:splat` and bundles functions with `esbuild`.
+- Ensure the site uses the **monorepo** root (`base = "."`) so dependencies like `@aws-sdk/*`, `file-type`, and `zod` are available during bundling.
+
+## 3. Deploy and verify uploads
+
+1. Deploy the site.
+2. Trigger the health check at `/api/healthz` to confirm functions respond with `X-Request-ID` headers.
+3. Upload a small PDF (< `R2_MULTIPART_THRESHOLD_MB`). Confirm the Network tab shows a single `PUT` request with the `x-amz-checksum-sha256` header.
+4. Upload a large PDF (> `R2_MULTIPART_THRESHOLD_MB`). Confirm:
+   - Multiple part uploads complete despite transient failures (retry/backoff).
+   - Final multipart completion succeeds and reported ETags match R2 objects (quotes removed client-side and server-side).
+5. Inspect the resulting objects in R2:
+   - Sizes match the source files.
+   - ETags match the client logs and `complete-multipart` response.
+6. Monitor server logs and `/metrics` for any queue or Redis regressions (T1a remains unchanged).
+
+## 4. Troubleshooting quick checks
+
+- Preflight errors: ensure `ALLOWED_ORIGINS` includes the requesting origin exactly (case-insensitive, no trailing slash).
+- 403/Signature mismatch: verify `REGION`, credentials, and `R2_S3_ENDPOINT` align with the bucket.
+- Multipart stalls: confirm `R2_MULTIPART_THRESHOLD_MB` isn’t set higher than the client build expects.
+
+Document any deviations in the release notes before shipping.

--- a/tests/client-upload-utils.test.ts
+++ b/tests/client-upload-utils.test.ts
@@ -56,7 +56,7 @@ describe('client upload utilities', () => {
     await vi.advanceTimersByTimeAsync(1000);
     const etag = await promise;
 
-    expect(etag).toBe('"abc123"');
+    expect(etag).toBe('abc123');
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 


### PR DESCRIPTION
## Audit Findings
- Files present:
  - `ls -la netlify/functions/`: OK — `_storage.ts`, `_utils.ts`, `complete-multipart.ts`, `get-job-status.ts`, `healthz.ts`, `ingest-pdf.ts`, `initiate-upload.ts` confirmed.
  - `grep -R "normalizeEtag" netlify/functions/`: OK — normalization already present in `complete-multipart.ts`.
  - `grep -R "x-amz-checksum-sha256" netlify/functions/ apps/web`: OK — header allowed in `_utils.ts` and set in `UploadPanel`.
  - `grep -R "CHUNK_SIZE|computeHashes" apps/web/src/lib/`: OK — streaming checksum helper exists.
- Frontend wiring:
  - XHR/fetch progress: OK — `uploadSingleWithProgress` reports progress events.
  - Multipart retry/backoff: OK — `uploadPartWithRetry` retries with exponential backoff.
- Config & deployment:
  - `netlify.toml` `/api/*` → `/.netlify/functions/:splat`: OK — redirect already present with `force = true`.
  - `[functions]` bundler settings: OK — `node_bundler = "esbuild"` configured.
  - Root `package.json` deps (`file-type`, `@aws-sdk/*`, `zod`): OK — all listed under dependencies.
- T1a preservation:
  - `apps/api/infra/redis.py`, `apps/worker/infra/redis.py`, `apps/worker/queues.py`, and metrics modules present and untouched.

## Gaps Addressed
- Normalize multipart ETags returned by the client retry helper and align regression tests so quoted values are stripped before completion.
- Document Netlify deployment configuration (env vars, proxy expectations, validation steps) and update `.env.example` placeholders with shared defaults to avoid misconfiguration drift.

## What Stayed Intact
- No modifications to T1a Redis/RQ/metrics modules or feature-flag pathways; upload hardening is isolated to client helpers, tests, and deployment docs.

## Post-Deploy Checklist
1. Set Netlify environment variables listed in `.env.example` for both Site and Functions contexts.
2. Confirm `/api/*` proxy traffic reaches the deployed Netlify Functions.
3. Upload a small PDF (< threshold) and verify the single PUT request carries `x-amz-checksum-sha256`.
4. Upload a large PDF (> threshold) and confirm multipart retries complete and ETags match after normalization.
5. Inspect R2 objects for matching ETags/sizes and correlate with client `X-Request-ID` logs.


------
https://chatgpt.com/codex/tasks/task_e_68dc523c6160832bb6feb25338bb035a