### PR TITLE
Fix pHash dependency handling and secure ops dashboard access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ PDF_MAX_MB=100
 NEXT_PUBLIC_PDF_MAX_MB=100
 PRESIGN_TTL=900
 REGION=<r2-or-aws-region>
-R2_S3_ENDPOINT=<accountid>.r2.cloudflarestorage.com
+R2_S3_ENDPOINT=example123.r2.cloudflarestorage.com
 R2_BUCKET=<bucket>
 R2_ACCESS_KEY_ID=***
 R2_SECRET_ACCESS_KEY=***
@@ -12,9 +12,18 @@ R2_MULTIPART_THRESHOLD_MB=50
 
 # Frontend configuration
 NEXT_PUBLIC_API_URL=<https://ledgerlift1.netlify.app or http://localhost:8888>
+NEXT_PUBLIC_SHOW_OPS=false
+ENABLE_OPS_ENDPOINTS=false
 NODE_ENV=development
 
 # Feature flags
 FEATURES_T1_QUEUE=false
 FEATURES_T2_OCR=false
 FEATURES_T3_AUDIT=false
+FEATURES_T1_CAS_PHASH=true
+
+# Worker tuning
+PHASH_PAGES=3
+PHASH_DISTANCE_MAX=6
+PARSER_MAX_SCHEDULES=10
+PARSER_MAX_EMPTY_PAGES=20

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -8,7 +8,7 @@ from slowapi.errors import RateLimitExceeded
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 from .settings import CORS_ALLOWED_ORIGINS
-from .routes import health, uploads, documents, processing, jobs_events
+from .routes import health, uploads, documents, processing, jobs_events, ops
 from .middleware import MetricsMiddleware, RequestIDMiddleware, LoggingMiddleware
 from apps.api.config import settings as api_settings
 
@@ -68,3 +68,4 @@ app.include_router(uploads.router)
 app.include_router(documents.router)
 app.include_router(processing.router)
 app.include_router(jobs_events.router)
+app.include_router(ops.router)

--- a/apps/api/app/routes/ops.py
+++ b/apps/api/app/routes/ops.py
@@ -1,0 +1,74 @@
+"""Operational endpoints for queue monitoring."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, List
+
+from fastapi import APIRouter, HTTPException
+from rq import Queue
+from rq.registry import (
+    DeferredJobRegistry,
+    FailedJobRegistry,
+    FinishedJobRegistry,
+    ScheduledJobRegistry,
+    StartedJobRegistry,
+)
+
+from apps.api.config import settings
+from apps.api.infra.redis import get_redis_connection, is_emergency_stopped
+
+router = APIRouter(prefix="/ops", tags=["ops"])
+
+
+def _queue_snapshot(queue_name: str, priority: str, connection) -> Dict[str, int | str]:
+    queue = Queue(queue_name, connection=connection)
+    registries = {
+        "started": StartedJobRegistry(queue_name, connection=connection),
+        "scheduled": ScheduledJobRegistry(queue_name, connection=connection),
+        "failed": FailedJobRegistry(queue_name, connection=connection),
+        "finished": FinishedJobRegistry(queue_name, connection=connection),
+        "deferred": DeferredJobRegistry(queue_name, connection=connection),
+    }
+
+    return {
+        "name": queue_name,
+        "priority": priority,
+        "size": queue.count(),
+        "started": registries["started"].count(),
+        "scheduled": registries["scheduled"].count(),
+        "failed": registries["failed"].count(),
+        "finished": registries["finished"].count(),
+        "deferred": registries["deferred"].count(),
+    }
+
+
+@router.get("/queues")
+def get_queue_dashboard() -> Dict[str, object]:
+    if not settings.enable_ops_endpoints:
+        raise HTTPException(
+            status_code=403,
+            detail={"error": "OPS_ACCESS_FORBIDDEN", "message": "Operations endpoints are disabled"},
+        )
+
+    if not settings.features_t1_queue:
+        raise HTTPException(
+            status_code=503,
+            detail={"error": "QUEUE_DISABLED", "message": "Queueing is temporarily disabled"},
+        )
+
+    connection = get_redis_connection()
+    queue_map: List[Dict[str, int | str]] = []
+    for priority, queue_name in (
+        ("high", settings.rq_high_queue),
+        ("default", settings.rq_default_queue),
+        ("low", settings.rq_low_queue),
+        ("dead", settings.rq_dlq),
+    ):
+        snapshot = _queue_snapshot(queue_name, priority, connection)
+        queue_map.append(snapshot)
+
+    return {
+        "queues": queue_map,
+        "emergency_stop": is_emergency_stopped(connection),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -25,6 +25,7 @@ class APIConfig(BaseSettings):
     metrics_auth: Optional[str] = None
     job_progress_ttl_seconds: int = 3600
     emergency_stop_key: str = "EMERGENCY_STOP"
+    enable_ops_endpoints: bool = False
 
     class Config:
         env_file = ".env"
@@ -45,6 +46,7 @@ class APIConfig(BaseSettings):
             "parse_timeout_ms": {"env": "PARSE_TIMEOUT_MS"},
             "metrics_auth": {"env": "METRICS_AUTH"},
             "emergency_stop_key": {"env": "EMERGENCY_STOP_KEY"},
+            "enable_ops_endpoints": {"env": "ENABLE_OPS_ENDPOINTS"},
         }
 
 

--- a/apps/api/migrations/versions/20240905_add_document_hash_columns.py
+++ b/apps/api/migrations/versions/20240905_add_document_hash_columns.py
@@ -1,0 +1,25 @@
+"""Add document hash columns"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20240905_add_document_hash_columns"
+down_revision = "add_performance_indexes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("documents") as batch_op:
+        batch_op.add_column(sa.Column("sha256_raw", sa.String(length=64), nullable=True))
+        batch_op.add_column(sa.Column("sha256_canonical", sa.String(length=64), nullable=True))
+        batch_op.create_index("ix_documents_sha256_raw", ["sha256_raw"], unique=False)
+        batch_op.create_index("ix_documents_sha256_canonical", ["sha256_canonical"], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("documents") as batch_op:
+        batch_op.drop_index("ix_documents_sha256_canonical")
+        batch_op.drop_index("ix_documents_sha256_raw")
+        batch_op.drop_column("sha256_canonical")
+        batch_op.drop_column("sha256_raw")

--- a/apps/api/tests/test_ops.py
+++ b/apps/api/tests/test_ops.py
@@ -1,0 +1,59 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from fastapi.testclient import TestClient
+
+from apps.api.app.main import app
+from apps.api.app.routes import ops
+
+
+class StubQueue:
+    def __init__(self, name: str, connection=None):
+        self.name = name
+        self._count = 3
+
+    def count(self) -> int:  # pragma: no cover - invoked indirectly
+        return self._count
+
+
+class StubRegistry:
+    def __init__(self, *_args, **_kwargs):
+        self._count = 1
+
+    def count(self) -> int:  # pragma: no cover - invoked indirectly
+        return self._count
+
+
+def test_ops_queues_returns_snapshot(monkeypatch):
+    monkeypatch.setattr(ops.settings, "enable_ops_endpoints", True)
+    monkeypatch.setattr(ops, "Queue", StubQueue)
+    monkeypatch.setattr(ops, "StartedJobRegistry", StubRegistry)
+    monkeypatch.setattr(ops, "ScheduledJobRegistry", StubRegistry)
+    monkeypatch.setattr(ops, "FailedJobRegistry", StubRegistry)
+    monkeypatch.setattr(ops, "FinishedJobRegistry", StubRegistry)
+    monkeypatch.setattr(ops, "DeferredJobRegistry", StubRegistry)
+    monkeypatch.setattr(ops, "get_redis_connection", lambda: object())
+    monkeypatch.setattr(ops, "is_emergency_stopped", lambda _conn: False)
+
+    client = TestClient(app)
+    response = client.get("/ops/queues")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "queues" in body
+    assert len(body["queues"]) == 4
+    assert body["queues"][0]["size"] == 3
+    assert body["emergency_stop"] is False
+    assert "timestamp" in body
+
+
+def test_ops_queues_returns_403_when_disabled(monkeypatch):
+    monkeypatch.setattr(ops.settings, "enable_ops_endpoints", False)
+
+    client = TestClient(app)
+    response = client.get("/ops/queues")
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["error"] == "OPS_ACCESS_FORBIDDEN"

--- a/apps/web/src/pages/ops/queues.tsx
+++ b/apps/web/src/pages/ops/queues.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useMemo, useState } from 'react';
+import Head from 'next/head';
+
+import { apiClient, QueueDashboard, QueuePriority, QueueSnapshot } from '../../lib/api';
+
+const SHOW_OPS = process.env.NEXT_PUBLIC_SHOW_OPS === 'true';
+
+function formatPriority(priority: QueuePriority) {
+  switch (priority) {
+    case 'high':
+      return 'High';
+    case 'low':
+      return 'Low';
+    case 'dead':
+      return 'Dead Letter';
+    default:
+      return 'Default';
+  }
+}
+
+function QueueTable({ queues }: { queues: QueueSnapshot[] }) {
+  return (
+    <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: 16 }}>
+      <thead>
+        <tr>
+          {['Priority', 'Queue', 'Queued', 'In Progress', 'Scheduled', 'Deferred', 'Failed', 'Finished'].map((header) => (
+            <th
+              key={header}
+              style={{
+                textAlign: 'left',
+                padding: '8px 12px',
+                borderBottom: '1px solid #e0e0e0',
+                fontWeight: 600,
+                fontSize: 14,
+              }}
+            >
+              {header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {queues.map((queue) => (
+          <tr key={`${queue.priority}-${queue.name}`}>
+            <td style={{ padding: '8px 12px', borderBottom: '1px solid #f0f0f0' }}>{formatPriority(queue.priority)}</td>
+            <td style={{ padding: '8px 12px', borderBottom: '1px solid #f0f0f0', fontFamily: 'monospace' }}>{queue.name}</td>
+            <td style={{ padding: '8px 12px', borderBottom: '1px solid #f0f0f0' }}>{queue.size}</td>
+            <td style={{ padding: '8px 12px', borderBottom: '1px solid #f0f0f0' }}>{queue.started}</td>
+            <td style={{ padding: '8px 12px', borderBottom: '1px solid #f0f0f0' }}>{queue.scheduled}</td>
+            <td style={{ padding: '8px 12px', borderBottom: '1px solid #f0f0f0' }}>{queue.deferred}</td>
+            <td style={{ padding: '8px 12px', borderBottom: '1px solid #f0f0f0', color: queue.failed > 0 ? '#c62828' : undefined }}>{queue.failed}</td>
+            <td style={{ padding: '8px 12px', borderBottom: '1px solid #f0f0f0' }}>{queue.finished}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default function QueueDashboardPage() {
+  const [snapshot, setSnapshot] = useState<QueueDashboard | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!SHOW_OPS) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchSnapshot = async () => {
+      const result = await apiClient.getQueueDashboard();
+      if (cancelled) {
+        return;
+      }
+
+      if (result.success) {
+        setSnapshot(result.data);
+        setError(null);
+      } else {
+        setError(result.error.message);
+      }
+      setLoading(false);
+    };
+
+    fetchSnapshot();
+    const interval = setInterval(fetchSnapshot, 15000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  const lastUpdated = useMemo(() => {
+    if (!snapshot?.timestamp) {
+      return null;
+    }
+    try {
+      return new Date(snapshot.timestamp).toLocaleString();
+    } catch (error) {
+      return snapshot.timestamp;
+    }
+  }, [snapshot?.timestamp]);
+
+  if (!SHOW_OPS) {
+    return (
+      <main style={{ maxWidth: 720, margin: '40px auto', padding: '0 16px' }}>
+        <Head>
+          <title>Queues • Ledger Lift</title>
+        </Head>
+        <h1>Operations dashboard disabled</h1>
+        <p style={{ color: '#666', lineHeight: 1.6 }}>
+          Set <code>NEXT_PUBLIC_SHOW_OPS=true</code> to enable the queue dashboard.
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Queue Dashboard • Ledger Lift</title>
+      </Head>
+      <main style={{ maxWidth: 960, margin: '40px auto', padding: '0 16px' }}>
+        <h1>Queue Dashboard</h1>
+        <p style={{ color: '#666', lineHeight: 1.6 }}>
+          Monitor queue depth and worker activity. Data refreshes every 15 seconds.
+        </p>
+
+        {snapshot?.emergency_stop && (
+          <div
+            style={{
+              marginTop: 16,
+              padding: '12px 16px',
+              borderRadius: 6,
+              backgroundColor: '#fff3cd',
+              border: '1px solid #ffeeba',
+              color: '#856404',
+            }}
+          >
+            <strong>Emergency stop active.</strong> Jobs are not being processed.
+          </div>
+        )}
+
+        {loading && (
+          <p style={{ marginTop: 24, color: '#555' }}>Loading queue metrics…</p>
+        )}
+
+        {!loading && error && (
+          <p style={{ marginTop: 24, color: '#c62828' }}>{error}</p>
+        )}
+
+        {!loading && !error && snapshot && (
+          <div style={{ marginTop: 24 }}>
+            <QueueTable queues={snapshot.queues} />
+            {lastUpdated && (
+              <p style={{ marginTop: 12, color: '#888', fontSize: 12 }}>
+                Last updated: {lastUpdated}
+              </p>
+            )}
+          </div>
+        )}
+      </main>
+    </>
+  );
+}

--- a/apps/worker/config.py
+++ b/apps/worker/config.py
@@ -13,7 +13,12 @@ class WorkerConfig(BaseSettings):
     features_t1_queue: bool = True
     features_t1_financial_detector: bool = True
     features_t1_financial_ml: bool = False
+    features_t1_cas_phash: bool = True
     cas_normalize_pdf: bool = True
+    phash_pages: int = 3
+    phash_distance_max: int = 6
+    parser_max_schedules: int = 10
+    parser_max_empty_pages: int = 20
     redis_url: str = "redis://localhost:6379/0"
     rq_default_queue: str = "default"
     rq_high_queue: str = "high"
@@ -34,6 +39,7 @@ class WorkerConfig(BaseSettings):
             "features_t1_queue": {"env": "FEATURES_T1_QUEUE"},
             "features_t1_financial_detector": {"env": "FEATURES_T1_FINANCIAL_DETECTOR"},
             "features_t1_financial_ml": {"env": "FEATURES_T1_FINANCIAL_ML"},
+            "features_t1_cas_phash": {"env": "FEATURES_T1_CAS_PHASH"},
             "cas_normalize_pdf": {"env": "CAS_NORMALIZE_PDF"},
             "redis_url": {"env": "REDIS_URL"},
             "rq_default_queue": {"env": "RQ_DEFAULT_QUEUE"},
@@ -46,6 +52,10 @@ class WorkerConfig(BaseSettings):
             "metrics_auth": {"env": "METRICS_AUTH"},
             "emergency_stop_key": {"env": "EMERGENCY_STOP_KEY"},
             "job_progress_ttl_seconds": {"env": "JOB_PROGRESS_TTL_SECONDS"},
+            "phash_pages": {"env": "PHASH_PAGES"},
+            "phash_distance_max": {"env": "PHASH_DISTANCE_MAX"},
+            "parser_max_schedules": {"env": "PARSER_MAX_SCHEDULES"},
+            "parser_max_empty_pages": {"env": "PARSER_MAX_EMPTY_PAGES"},
         }
 
 

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -25,6 +25,10 @@ dev = [
   "pytest==8.2.0",
   "ruff==0.6.2"
 ]
+phash = [
+  "imagehash==4.3.1",
+  "Pillow==10.2.0"
+]
 
 [tool.ruff]
 line-length = 100

--- a/apps/worker/services/__init__.py
+++ b/apps/worker/services/__init__.py
@@ -1,1 +1,22 @@
 """Worker side services."""
+
+from .cas import CASHashes, compute_pdf_hashes
+from .cas_phash import (
+    CASPhashResult,
+    ensure_phash_support,
+    compute_pdf_phashes,
+    find_duplicate_by_phash,
+    phash_distance,
+    store_pdf_phashes,
+)
+
+__all__ = [
+    "CASHashes",
+    "CASPhashResult",
+    "compute_pdf_hashes",
+    "ensure_phash_support",
+    "compute_pdf_phashes",
+    "find_duplicate_by_phash",
+    "phash_distance",
+    "store_pdf_phashes",
+]

--- a/apps/worker/services/cas_phash.py
+++ b/apps/worker/services/cas_phash.py
@@ -1,0 +1,250 @@
+"""Perceptual hashing helpers for CAS deduplication."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, TYPE_CHECKING, Any
+
+import fitz  # type: ignore
+
+try:  # pragma: no cover - optional dependency guard
+    from PIL import Image  # type: ignore
+except ImportError as pillow_error:  # pragma: no cover - exercised when Pillow missing
+    Image = None  # type: ignore[assignment]
+    _PIL_IMPORT_ERROR = pillow_error
+else:  # pragma: no cover - dependency available
+    _PIL_IMPORT_ERROR = None
+
+try:  # pragma: no cover - optional dependency guard
+    from imagehash import ImageHash, hex_to_hash, phash  # type: ignore
+except ImportError as imagehash_error:  # pragma: no cover - exercised when imagehash missing
+    ImageHash = None  # type: ignore[assignment]
+    hex_to_hash = None  # type: ignore[assignment]
+    phash = None  # type: ignore[assignment]
+    _IMAGEHASH_IMPORT_ERROR = imagehash_error
+else:  # pragma: no cover - dependency available
+    _IMAGEHASH_IMPORT_ERROR = None
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    from PIL.Image import Image as PILImageType
+else:  # pragma: no cover - runtime fallback
+    PILImageType = Any
+
+logger = logging.getLogger(__name__)
+
+PHASH_KEY_PREFIX = "cas:phash"
+
+
+@dataclass(frozen=True)
+class CASPhashResult:
+    """Computed perceptual hashes for the first rendered pages."""
+
+    hashes: Sequence[str]
+    pages_processed: int
+
+    def as_list(self) -> List[str]:
+        return list(self.hashes)
+
+
+def ensure_phash_support() -> None:
+    """Raise an informative error when pHash dependencies are unavailable."""
+
+    if Image is None:
+        raise ImportError(
+            "Pillow is required for CAS pHash deduplication. Install ledger-lift-worker[phash]."
+        ) from _PIL_IMPORT_ERROR
+
+    if any(dependency is None for dependency in (ImageHash, hex_to_hash, phash)):
+        raise ImportError(
+            "imagehash is required for CAS pHash deduplication. Install ledger-lift-worker[phash]."
+        ) from _IMAGEHASH_IMPORT_ERROR
+
+
+def _render_page(doc: fitz.Document, page_index: int) -> Optional["PILImageType"]:
+    """Render a PDF page to a Pillow image."""
+
+    try:
+        page = doc.load_page(page_index)
+        pix = page.get_pixmap(matrix=fitz.Matrix(2, 2))
+        mode = "RGBA" if pix.alpha else "RGB"
+        image = Image.frombytes(mode, [pix.width, pix.height], pix.samples)
+        if mode == "RGBA":
+            image = image.convert("RGB")
+        return image
+    except Exception as exc:  # pragma: no cover - defensive guard for corrupt pages
+        logger.warning("Failed to render page %s for pHash: %s", page_index, exc)
+        return None
+
+
+def compute_pdf_phashes(pdf_bytes: bytes, *, max_pages: int = 3) -> CASPhashResult:
+    """Compute perceptual hashes for the first ``max_pages`` pages of a PDF."""
+
+    if max_pages <= 0:
+        return CASPhashResult(hashes=(), pages_processed=0)
+
+    ensure_phash_support()
+
+    hashes: List[str] = []
+    try:
+        with fitz.open(stream=pdf_bytes, filetype="pdf") as doc:
+            page_count = min(len(doc), max_pages)
+            for page_index in range(page_count):
+                image = _render_page(doc, page_index)
+                if image is None:
+                    continue
+                hash_value = phash(image)
+                hashes.append(str(hash_value))
+    except Exception as exc:  # pragma: no cover - corrupted PDF defensive guard
+        logger.warning("Failed to compute pHash: %s", exc)
+        return CASPhashResult(hashes=tuple(hashes), pages_processed=len(hashes))
+
+    return CASPhashResult(hashes=tuple(hashes), pages_processed=len(hashes))
+
+
+def phash_distance(hash_a: str, hash_b: str) -> int:
+    """Return the Hamming distance between two perceptual hash hex strings."""
+
+    ensure_phash_support()
+
+    try:
+        return abs(hex_to_hash(hash_a) - hex_to_hash(hash_b))
+    except Exception as exc:  # pragma: no cover - invalid hash defensive guard
+        logger.debug("Failed to compute pHash distance: %s", exc)
+        return 64
+
+
+def _doc_key(document_id: str) -> str:
+    return f"{PHASH_KEY_PREFIX}:doc:{document_id}"
+
+
+def _page_key(page_index: int, hash_hex: str) -> str:
+    return f"{PHASH_KEY_PREFIX}:page:{page_index}:{hash_hex}"
+
+
+def store_pdf_phashes(connection, document_id: str, hashes: Sequence[str]) -> None:
+    """Persist pHashes in Redis for future deduplication."""
+
+    if not hashes:
+        return
+
+    mapping = {str(idx): value for idx, value in enumerate(hashes)}
+    pipeline = getattr(connection, "pipeline", None)
+
+    if callable(pipeline):
+        pipe = pipeline()
+    else:
+        pipe = None
+
+    executor = pipe or connection
+
+    executor.hset(_doc_key(document_id), mapping=mapping)
+    for idx, hash_hex in enumerate(hashes):
+        executor.sadd(_page_key(idx, hash_hex), document_id)
+
+    if pipe is not None:
+        pipe.execute()
+
+
+def _decode(value: bytes | str | None) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return value
+
+
+def _collect_candidate_ids(connection, hashes: Sequence[str]) -> set[str]:
+    candidates: set[str] = set()
+    for page_index, hash_hex in enumerate(hashes):
+        key = _page_key(page_index, hash_hex)
+        try:
+            page_candidates = connection.smembers(key)
+        except Exception as exc:  # pragma: no cover - redis runtime guard
+            logger.debug("Failed to read pHash candidates: %s", exc)
+            continue
+        for candidate in page_candidates or []:
+            candidate_id = _decode(candidate)
+            if candidate_id:
+                candidates.add(candidate_id)
+    return candidates
+
+
+def _load_candidate_hashes(connection, document_id: str) -> List[str]:
+    try:
+        stored = connection.hgetall(_doc_key(document_id))
+    except Exception as exc:  # pragma: no cover - redis runtime guard
+        logger.debug("Failed to fetch pHash record for %s: %s", document_id, exc)
+        return []
+
+    if not stored:
+        return []
+
+    decoded: dict[int, str] = {}
+    for raw_key, value in stored.items():
+        try:
+            if isinstance(raw_key, bytes):
+                index = int(raw_key.decode("utf-8"))
+            else:
+                index = int(raw_key)
+        except (TypeError, ValueError):
+            continue
+        decoded[index] = _decode(value) or ""
+
+    if not decoded:
+        return []
+
+    max_index = max(decoded.keys())
+    return [decoded.get(index, "") for index in range(max_index + 1)]
+
+
+def _hashes_within_threshold(
+    target_hashes: Sequence[str],
+    candidate_hashes: Sequence[str],
+    *,
+    distance_max: int,
+) -> bool:
+    if not candidate_hashes:
+        return False
+
+    compare_count = min(len(target_hashes), len(candidate_hashes))
+    if compare_count == 0:
+        return False
+
+    for idx in range(compare_count):
+        distance = phash_distance(target_hashes[idx], candidate_hashes[idx])
+        if distance > distance_max:
+            return False
+    return True
+
+
+def find_duplicate_by_phash(
+    connection,
+    hashes: Sequence[str],
+    *,
+    distance_max: int,
+    exclude_document_id: Optional[str] = None,
+) -> Optional[str]:
+    """Return the document id of a near-duplicate PDF if one is indexed."""
+
+    if not hashes:
+        return None
+
+    candidate_ids = _collect_candidate_ids(connection, hashes)
+    if exclude_document_id:
+        candidate_ids.discard(exclude_document_id)
+
+    for candidate in candidate_ids:
+        candidate_hashes = _load_candidate_hashes(connection, candidate)
+        if _hashes_within_threshold(hashes, candidate_hashes, distance_max=distance_max):
+            return candidate
+    return None
+
+
+__all__ = [
+    "CASPhashResult",
+    "ensure_phash_support",
+    "compute_pdf_phashes",
+    "find_duplicate_by_phash",
+    "phash_distance",
+    "store_pdf_phashes",
+]

--- a/apps/worker/tests/test_cas_phash.py
+++ b/apps/worker/tests/test_cas_phash.py
@@ -1,0 +1,118 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+"""Tests for perceptual hashing utilities."""
+
+from typing import Dict, Set
+
+import fitz  # type: ignore
+import pytest
+
+pytest.importorskip("imagehash")
+pytest.importorskip("PIL.Image")
+
+from apps.worker.services.cas_phash import (
+    CASPhashResult,
+    compute_pdf_phashes,
+    find_duplicate_by_phash,
+    phash_distance,
+    store_pdf_phashes,
+)
+
+
+class FakeRedis:
+    """Minimal Redis-like store for unit testing."""
+
+    def __init__(self):
+        self.hashes: Dict[str, Dict[str, str]] = {}
+        self.sets: Dict[str, Set[str]] = {}
+
+    def pipeline(self):  # pragma: no cover - exercised indirectly
+        return self
+
+    def hset(self, key: str, mapping: Dict[str, str]):
+        self.hashes.setdefault(key, {}).update(mapping)
+
+    def sadd(self, key: str, value: str):
+        self.sets.setdefault(key, set()).add(value)
+
+    def execute(self):  # pragma: no cover - provided for pipeline API compatibility
+        return []
+
+    def smembers(self, key: str):
+        return {member.encode("utf-8") for member in self.sets.get(key, set())}
+
+    def hgetall(self, key: str):
+        stored = self.hashes.get(key, {})
+        return {k.encode("utf-8"): v.encode("utf-8") for k, v in stored.items()}
+
+
+@pytest.fixture
+def sample_pdf() -> bytes:
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "Sample Report")
+    metadata = doc.metadata
+    metadata["producer"] = "LedgerLift"
+    doc.set_metadata(metadata)
+    pdf_bytes = doc.tobytes()
+    doc.close()
+    return pdf_bytes
+
+
+@pytest.fixture
+def similar_pdf(sample_pdf: bytes) -> bytes:
+    with fitz.open(stream=sample_pdf, filetype="pdf") as original:
+        clone = fitz.open()
+        for page_index in range(len(original)):
+            page = clone.new_page()
+            page.show_pdf_page(page.rect, original, page_index)
+        metadata = clone.metadata
+        metadata["producer"] = "AnotherProducer"
+        metadata["title"] = "Updated title"
+        clone.set_metadata(metadata)
+        result = clone.tobytes()
+        clone.close()
+    return result
+
+
+def test_compute_pdf_phashes_returns_pages(sample_pdf: bytes):
+    result = compute_pdf_phashes(sample_pdf, max_pages=3)
+    assert isinstance(result, CASPhashResult)
+    assert result.hashes
+    assert result.pages_processed == len(result.hashes)
+
+
+def test_phash_distance_with_metadata_change(sample_pdf: bytes, similar_pdf: bytes):
+    first = compute_pdf_phashes(sample_pdf)
+    second = compute_pdf_phashes(similar_pdf)
+    assert first.hashes and second.hashes
+    assert phash_distance(first.hashes[0], second.hashes[0]) == 0
+
+
+def test_find_duplicate_by_phash_matches(sample_pdf: bytes, similar_pdf: bytes):
+    store = FakeRedis()
+    original = compute_pdf_phashes(sample_pdf)
+    store_pdf_phashes(store, "doc-1", original.hashes)
+
+    duplicate = compute_pdf_phashes(similar_pdf)
+    doc_id = find_duplicate_by_phash(store, duplicate.hashes, distance_max=6, exclude_document_id="doc-2")
+    assert doc_id == "doc-1"
+
+
+def test_find_duplicate_by_phash_respects_threshold(sample_pdf: bytes):
+    store = FakeRedis()
+    original = compute_pdf_phashes(sample_pdf)
+    store_pdf_phashes(store, "doc-1", original.hashes)
+
+    blank_doc = fitz.open()
+    page = blank_doc.new_page()
+    page.insert_text((72, 72), "Totally different content")
+    mutated_pdf = blank_doc.tobytes()
+    blank_doc.close()
+
+    mutated_hashes = compute_pdf_phashes(mutated_pdf).hashes
+    doc_id = find_duplicate_by_phash(store, mutated_hashes, distance_max=0)
+    assert doc_id is None


### PR DESCRIPTION
## Summary
- add an enable_ops_endpoints toggle, document its env default, and enforce it on the /ops/queues API with updated coverage
- introduce an Alembic migration for the new document hash columns
- make pHash dependencies optional with explicit guards, improved fallback metadata, and type-safe queue priority wiring on the web client

## Testing
- pytest apps/api/tests/test_ops.py
- pytest apps/worker/tests/test_cas_phash.py

------
https://chatgpt.com/codex/tasks/task_e_68dc5cebf5c0832ba024f84d0409d8e4