### PR TITLE
Handle missing client env vars in function config

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 const booleanString = z
-  .enum(['true', 'false'])
+  .union([z.enum(['true', 'false']), z.undefined()])
   .transform((value) => value === 'true');
 
 const normalizeOrigin = (origin: string) => origin.toLowerCase().replace(/\/$/, '');
@@ -19,9 +19,14 @@ const envSchema = z
     PDF_MAX_MB: z.coerce
       .number({ invalid_type_error: 'PDF_MAX_MB must be a number' })
       .positive('PDF_MAX_MB must be greater than 0'),
-    NEXT_PUBLIC_PDF_MAX_MB: z.coerce
-      .number({ invalid_type_error: 'NEXT_PUBLIC_PDF_MAX_MB must be a number' })
-      .positive('NEXT_PUBLIC_PDF_MAX_MB must be greater than 0'),
+    NEXT_PUBLIC_PDF_MAX_MB: z
+      .union([
+        z.coerce
+          .number({ invalid_type_error: 'NEXT_PUBLIC_PDF_MAX_MB must be a number' })
+          .positive('NEXT_PUBLIC_PDF_MAX_MB must be greater than 0'),
+        z.undefined(),
+      ])
+      .optional(),
     PRESIGN_TTL: z.coerce
       .number({ invalid_type_error: 'PRESIGN_TTL must be a number' })
       .positive('PRESIGN_TTL must be greater than 0')
@@ -86,7 +91,7 @@ export function loadEnv(customEnv: NodeJS.ProcessEnv = process.env) {
       ALLOWED_ORIGINS_NORMALIZED: allowedOrigins.map(normalizeOrigin),
       PDF_MAX_MB: parsed.PDF_MAX_MB,
       PDF_MAX_BYTES: parsed.PDF_MAX_MB * megabyte,
-      NEXT_PUBLIC_PDF_MAX_MB: parsed.NEXT_PUBLIC_PDF_MAX_MB,
+      NEXT_PUBLIC_PDF_MAX_MB: parsed.NEXT_PUBLIC_PDF_MAX_MB ?? parsed.PDF_MAX_MB,
       PRESIGN_TTL: parsed.PRESIGN_TTL,
       REGION: parsed.REGION,
       R2_S3_ENDPOINT: parsed.R2_S3_ENDPOINT.startsWith('http')

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -25,6 +25,30 @@ describe('environment configuration', () => {
     expect(env.NEXT_PUBLIC_API_URL).toBe('');
   });
 
+  it('falls back to PDF_MAX_MB when NEXT_PUBLIC_PDF_MAX_MB is missing', async () => {
+    const module = await loadModule<typeof import('../src/config/env')>(
+      '../src/config/env',
+      { NEXT_PUBLIC_PDF_MAX_MB: undefined }
+    );
+
+    const env = module.loadEnv();
+    expect(env.NEXT_PUBLIC_PDF_MAX_MB).toBe(env.PDF_MAX_MB);
+  });
+
+  it('defaults optional feature flags to false', async () => {
+    const module = await loadModule<typeof import('../src/config/env')>(
+      '../src/config/env',
+      {
+        FEATURES_T1_QUEUE: undefined,
+        FEATURES_T2_OCR: undefined,
+        FEATURES_T3_AUDIT: undefined,
+      }
+    );
+
+    const env = module.loadEnv();
+    expect(env.FEATURES).toEqual({ T1_QUEUE: false, T2_OCR: false, T3_AUDIT: false });
+  });
+
   it('fails fast when allowed origins are missing', async () => {
     await expect(
       loadModule('../src/config/env', { ALLOWED_ORIGINS: '' })


### PR DESCRIPTION
## Summary
- allow optional boolean feature flag environment variables to default to `false`
- default `NEXT_PUBLIC_PDF_MAX_MB` to the server-side `PDF_MAX_MB` when omitted
- extend environment configuration tests to cover the new defaults

## Testing
- npx vitest run tests/env.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dca5250fd0832bb1f81a88b75d6344