### PR TITLE
Handle missing NEXT_PUBLIC_PDF_MAX_MB in Netlify functions

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -6,6 +6,12 @@ const booleanString = z
 
 const normalizeOrigin = (origin: string) => origin.toLowerCase().replace(/\/$/, '');
 
+const positiveNumber = (field: string) =>
+  z
+    .coerce
+    .number({ invalid_type_error: `${field} must be a number` })
+    .positive(`${field} must be greater than 0`);
+
 const envSchema = z
   .object({
     NEXT_PUBLIC_API_URL: z
@@ -16,12 +22,8 @@ const envSchema = z
       .optional()
       .default(''),
     ALLOWED_ORIGINS: z.string().min(1, 'ALLOWED_ORIGINS is required'),
-    PDF_MAX_MB: z.coerce
-      .number({ invalid_type_error: 'PDF_MAX_MB must be a number' })
-      .positive('PDF_MAX_MB must be greater than 0'),
-    NEXT_PUBLIC_PDF_MAX_MB: z.coerce
-      .number({ invalid_type_error: 'NEXT_PUBLIC_PDF_MAX_MB must be a number' })
-      .positive('NEXT_PUBLIC_PDF_MAX_MB must be greater than 0'),
+    PDF_MAX_MB: positiveNumber('PDF_MAX_MB'),
+    NEXT_PUBLIC_PDF_MAX_MB: positiveNumber('NEXT_PUBLIC_PDF_MAX_MB').optional(),
     PRESIGN_TTL: z.coerce
       .number({ invalid_type_error: 'PRESIGN_TTL must be a number' })
       .positive('PRESIGN_TTL must be greater than 0')
@@ -77,6 +79,7 @@ export function loadEnv(customEnv: NodeJS.ProcessEnv = process.env) {
     }
 
     const megabyte = 1024 * 1024;
+    const nextPublicPdfMaxMb = parsed.NEXT_PUBLIC_PDF_MAX_MB ?? parsed.PDF_MAX_MB;
 
     return {
       NEXT_PUBLIC_API_URL: parsed.NEXT_PUBLIC_API_URL
@@ -86,7 +89,7 @@ export function loadEnv(customEnv: NodeJS.ProcessEnv = process.env) {
       ALLOWED_ORIGINS_NORMALIZED: allowedOrigins.map(normalizeOrigin),
       PDF_MAX_MB: parsed.PDF_MAX_MB,
       PDF_MAX_BYTES: parsed.PDF_MAX_MB * megabyte,
-      NEXT_PUBLIC_PDF_MAX_MB: parsed.NEXT_PUBLIC_PDF_MAX_MB,
+      NEXT_PUBLIC_PDF_MAX_MB: nextPublicPdfMaxMb,
       PRESIGN_TTL: parsed.PRESIGN_TTL,
       REGION: parsed.REGION,
       R2_S3_ENDPOINT: parsed.R2_S3_ENDPOINT.startsWith('http')

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -25,6 +25,16 @@ describe('environment configuration', () => {
     expect(env.NEXT_PUBLIC_API_URL).toBe('');
   });
 
+  it('defaults NEXT_PUBLIC_PDF_MAX_MB to PDF_MAX_MB when omitted', async () => {
+    const module = await loadModule<typeof import('../src/config/env')>(
+      '../src/config/env',
+      { NEXT_PUBLIC_PDF_MAX_MB: undefined }
+    );
+
+    const env = module.loadEnv();
+    expect(env.NEXT_PUBLIC_PDF_MAX_MB).toBe(env.PDF_MAX_MB);
+  });
+
   it('fails fast when allowed origins are missing', async () => {
     await expect(
       loadModule('../src/config/env', { ALLOWED_ORIGINS: '' })


### PR DESCRIPTION
## Summary
- allow the Netlify/server runtime to omit NEXT_PUBLIC_PDF_MAX_MB and fall back to PDF_MAX_MB
- add a regression test that verifies the fallback logic

## Testing
- pnpm test *(fails: network restrictions prevented Corepack from downloading pnpm 9.6.0)*

------
https://chatgpt.com/codex/tasks/task_e_68dca5250fd0832bb1f81a88b75d6344