### PR TITLE
Fix Netlify utilities and map new ORM models

### DIFF
--- a/apps/api/app/db.py
+++ b/apps/api/app/db.py
@@ -221,7 +221,15 @@ def create_tables():
     """Create database tables if they don't exist."""
     try:
         # Import models inside function to avoid circular imports
-        from .models import Document, Page, ProcessingEvent, Artifact  # noqa
+        from .models import (
+            Document,
+            Page,
+            ProcessingEvent,
+            Artifact,
+            AuditEvent,
+            CostRecord,
+            JobSchedule,
+        )  # noqa: F401
         Base.metadata.create_all(bind=db_manager.engine)
         logger.info("Database tables created successfully")
     except Exception as e:

--- a/apps/api/app/models/audit.py
+++ b/apps/api/app/models/audit.py
@@ -1,16 +1,39 @@
-from sqlalchemy import Column, String, TIMESTAMP, Index
-from sqlalchemy.dialects.postgresql import UUID, JSONB
-from sqlalchemy.sql import func, text
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
 import uuid
 
-class AuditEvent:
+from sqlalchemy import String, TIMESTAMP
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func, text
+
+from apps.api.app.db import Base
+
+
+class AuditEvent(Base):
     __tablename__ = 'audit_events'
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    job_id = Column(UUID(as_uuid=True), nullable=False, index=True)
-    event_type = Column(String(50), nullable=False, index=True)
-    user_id = Column(String(255), nullable=True)
-    ip_address = Column(String(45), nullable=True)
-    trace_id = Column(UUID(as_uuid=True), nullable=True, index=True)
-    idempotency_key = Column(String(64), nullable=False)
-    metadata = Column(JSONB, nullable=False, server_default=text("'{}'::jsonb"))
-    created_at = Column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text('gen_random_uuid()'),
+    )
+    job_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    event_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    user_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    ip_address: Mapped[str | None] = mapped_column(String(45), nullable=True)
+    trace_id: Mapped[str | None] = mapped_column(String(255), nullable=True, index=True)
+    idempotency_key: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    metadata: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+        default=dict,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )

--- a/apps/api/app/models/costs.py
+++ b/apps/api/app/models/costs.py
@@ -1,16 +1,38 @@
-from sqlalchemy import Column, String, Integer, TIMESTAMP
-from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.sql import func
+from __future__ import annotations
+
+from datetime import datetime
 import uuid
 
-class CostRecord:
+from sqlalchemy import Integer, String, TIMESTAMP
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func, text
+
+from apps.api.app.db import Base
+
+
+class CostRecord(Base):
     __tablename__ = 'cost_records'
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    job_id = Column(UUID(as_uuid=True), nullable=False, index=True)
-    user_id = Column(String(255), nullable=True, index=True)
-    provider = Column(String(50), nullable=False)
-    pages = Column(Integer, nullable=False)
-    cost_cents = Column(Integer, nullable=False)
-    status = Column(String(20), nullable=False, default='PENDING')
-    created_at = Column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
-    completed_at = Column(TIMESTAMP(timezone=True), nullable=True)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text('gen_random_uuid()'),
+    )
+    job_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    user_id: Mapped[str | None] = mapped_column(String(255), nullable=True, index=True)
+    provider: Mapped[str] = mapped_column(String(50), nullable=False)
+    pages: Mapped[int] = mapped_column(Integer, nullable=False)
+    cost_cents: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default='PENDING',
+        server_default=text("'PENDING'"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)

--- a/apps/api/app/models/schedules.py
+++ b/apps/api/app/models/schedules.py
@@ -1,14 +1,46 @@
-from sqlalchemy import Column, String, Integer, Float, TIMESTAMP
-from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.sql import func
+from __future__ import annotations
+
+from datetime import datetime
 import uuid
 
-class JobSchedule:
+from sqlalchemy import Float, Integer, String, TIMESTAMP
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func, text
+
+from apps.api.app.db import Base
+
+
+class JobSchedule(Base):
     __tablename__ = 'job_schedules'
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    job_id = Column(UUID(as_uuid=True), nullable=False, index=True)
-    name = Column(String(255), nullable=False)
-    confidence = Column(Float, nullable=False, default=0.0)
-    row_count = Column(Integer, nullable=False, default=0)
-    col_count = Column(Integer, nullable=False, default=0)
-    created_at = Column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text('gen_random_uuid()'),
+    )
+    job_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    confidence: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        default=0.0,
+        server_default=text('0'),
+    )
+    row_count: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        server_default=text('0'),
+    )
+    col_count: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        server_default=text('0'),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )

--- a/apps/api/app/routes/schedules.py
+++ b/apps/api/app/routes/schedules.py
@@ -11,7 +11,7 @@ router = APIRouter(prefix="/v1/jobs", tags=["jobs"])
 
 @router.get("/{job_id}/schedules")
 async def get_schedules(job_id: UUID)->Dict[str,Any]:
-    from apps.api.app.database import get_db_session
+    from apps.api.app.db import get_db_session
     async with get_db_session() as s:
         res=await s.execute(select(JobSchedule).where(JobSchedule.job_id==job_id).order_by(JobSchedule.created_at))
         rows=res.scalars().all()
@@ -36,7 +36,7 @@ async def export_selected(job_id: UUID, payload: Dict[str, Any])->StreamingRespo
         raise HTTPException(status_code=500, detail="openpyxl not installed on API")
     
     sel = set(payload.get("selectedScheduleIds") or [])
-    from apps.api.app.database import get_db_session
+    from apps.api.app.db import get_db_session
     async with get_db_session() as s:
         res=await s.execute(select(JobSchedule).where(JobSchedule.job_id==job_id))
         rows=[r for r in res.scalars().all() if str(r.id) in sel] if sel else []

--- a/apps/api/app/services/gdpr.py
+++ b/apps/api/app/services/gdpr.py
@@ -23,7 +23,7 @@ async def _artifacts(job)->List[Dict[str,str]]:
     return out
 
 async def initiate_job_deletion(job_id: UUID, user_id: Optional[str]=None, trace_id: Optional[UUID]=None)->Dict[str,Any]:
-    from apps.api.app.database import get_db_session
+    from apps.api.app.db import get_db_session
     async with get_db_session() as s:
         from sqlalchemy import text
         res=await s.execute(text("SELECT id, status, source_key, processed_key, export_key, bucket FROM jobs WHERE id = :id FOR UPDATE"), {"id": str(job_id)})
@@ -59,7 +59,7 @@ async def initiate_job_deletion(job_id: UUID, user_id: Optional[str]=None, trace
 async def _execute_deletion(job_id: UUID, max_retries:int=3):
     for attempt in range(max_retries):
         try:
-            from apps.api.app.database import get_db_session
+            from apps.api.app.db import get_db_session
             async with get_db_session() as s:
                 from sqlalchemy import text
                 res=await s.execute(text("SELECT deletion_manifest FROM jobs WHERE id = :id"), {"id": str(job_id)})
@@ -99,7 +99,7 @@ async def _execute_deletion(job_id: UUID, max_retries:int=3):
             if attempt < max_retries-1: await asyncio.sleep(2**attempt)
 
 async def sweep_stale_deletions():
-    from apps.api.app.database import get_db_session
+    from apps.api.app.db import get_db_session
     async with get_db_session() as s:
         from sqlalchemy import text
         res=await s.execute(text("SELECT id FROM jobs WHERE deletion_manifest IS NOT NULL"))

--- a/netlify/functions/_utils.ts
+++ b/netlify/functions/_utils.ts
@@ -1,29 +1,174 @@
-import { HandlerEvent, HandlerContext, HandlerResponse } from "@netlify/functions";
+import { randomUUID } from 'crypto';
+import {
+  Handler,
+  HandlerContext,
+  HandlerEvent,
+  HandlerResponse,
+} from '@netlify/functions';
 
-export function createHandler(fn: (event: HandlerEvent, context: HandlerContext) => Promise<any>) {
-  return async (event: HandlerEvent, context: HandlerContext): Promise<HandlerResponse> => {
+type HttpMethod =
+  | 'GET'
+  | 'HEAD'
+  | 'POST'
+  | 'PUT'
+  | 'PATCH'
+  | 'DELETE'
+  | 'OPTIONS';
+
+type HandlerUtilities = {
+  json: (statusCode: number, body: unknown, headers?: Record<string, string>) => HandlerResponse;
+  text: (statusCode: number, body: string, headers?: Record<string, string>) => HandlerResponse;
+  requestId: string;
+};
+
+type WrappedHandler = (
+  event: HandlerEvent,
+  context: HandlerContext,
+  utils: HandlerUtilities
+) => Promise<HandlerResponse | Record<string, unknown> | string | void>;
+
+function createUtilities(requestId: string): HandlerUtilities {
+  return {
+    json(statusCode, body, headers = {}) {
+      return {
+        statusCode,
+        headers: { 'Content-Type': 'application/json', ...headers },
+        body: JSON.stringify(body ?? {}),
+      };
+    },
+    text(statusCode, body, headers = {}) {
+      return {
+        statusCode,
+        headers: { 'Content-Type': 'text/plain', ...headers },
+        body,
+      };
+    },
+    requestId,
+  };
+}
+
+function normaliseMethods(methods: HttpMethod[] | undefined): string[] | undefined {
+  return methods?.map((method) => method.toUpperCase());
+}
+
+function buildErrorResponse(
+  err: unknown,
+  utils: HandlerUtilities
+): HandlerResponse {
+  const error = err as { statusCode?: number; message?: string; body?: string } | undefined;
+  const statusCode = error?.statusCode && Number.isInteger(error.statusCode)
+    ? error.statusCode
+    : 500;
+
+  if (error?.body) {
+    return {
+      statusCode,
+      headers: { 'Content-Type': 'application/json' },
+      body: error.body,
+    };
+  }
+
+  const message = error?.message ?? 'Internal Server Error';
+  return utils.json(statusCode, { ok: false, error: message, requestId: utils.requestId });
+}
+
+function normaliseResult(
+  result: HandlerResponse | Record<string, unknown> | string | void,
+  utils: HandlerUtilities
+): HandlerResponse {
+  if (result && typeof result === 'object' && 'statusCode' in result) {
+    return result as HandlerResponse;
+  }
+
+  if (typeof result === 'string') {
+    return utils.text(200, result);
+  }
+
+  const payload =
+    result && typeof result === 'object' ? result : {};
+
+  return utils.json(200, payload);
+}
+
+export function createHandler(handler: WrappedHandler): Handler;
+export function createHandler(methods: HttpMethod[], handler: WrappedHandler): Handler;
+export function createHandler(
+  methodsOrHandler: HttpMethod[] | WrappedHandler,
+  maybeHandler?: WrappedHandler
+): Handler {
+  const methods = Array.isArray(methodsOrHandler)
+    ? normaliseMethods(methodsOrHandler)
+    : undefined;
+  const handler = (Array.isArray(methodsOrHandler)
+    ? maybeHandler
+    : methodsOrHandler) as WrappedHandler;
+
+  if (!handler) {
+    throw new Error('createHandler requires a handler function');
+  }
+
+  return async (event, context) => {
+    const requestId =
+      event.headers?.['x-request-id'] ||
+      event.headers?.['X-Request-Id'] ||
+      context.awsRequestId ||
+      randomUUID();
+    const utils = createUtilities(requestId);
+
+    if (
+      methods &&
+      event.httpMethod &&
+      !methods.includes(event.httpMethod.toUpperCase())
+    ) {
+      return utils.json(
+        405,
+        {
+          ok: false,
+          error: `Method ${event.httpMethod} not allowed`,
+          requestId,
+        },
+        { Allow: methods.join(', ') }
+      );
+    }
+
     try {
-      const result = await fn(event, context);
-      return {
-        statusCode: 200,
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(result),
-      };
-    } catch (err: any) {
-      return {
-        statusCode: err.statusCode || 500,
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ error: err.message }),
-      };
+      const result = await handler(event, context, utils);
+      return normaliseResult(result, utils);
+    } catch (err) {
+      return buildErrorResponse(err, utils);
     }
   };
+}
+
+export function parseJsonBody<T>(event: HandlerEvent): T {
+  if (!event.body) {
+    return {} as T;
+  }
+
+  const raw = event.isBase64Encoded
+    ? Buffer.from(event.body, 'base64').toString('utf8')
+    : event.body;
+
+  if (!raw.trim()) {
+    return {} as T;
+  }
+
+  try {
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    const err = new Error('Invalid JSON body');
+    (err as any).statusCode = 400;
+    throw err;
+  }
 }
 
 export function binaryResponse(data: Buffer, contentType: string): HandlerResponse {
   return {
     statusCode: 200,
-    headers: { "Content-Type": contentType },
-    body: data.toString("base64"),
+    headers: { 'Content-Type': contentType },
+    body: data.toString('base64'),
     isBase64Encoded: true,
   };
 }
+
+export type { HandlerUtilities };

--- a/netlify/functions/delete-job.ts
+++ b/netlify/functions/delete-job.ts
@@ -1,21 +1,96 @@
-import { Handler } from "@netlify/functions";
-import { getPool } from "./_database";
-import { createHandler } from "./_utils";
+import { Handler } from '@netlify/functions';
+import { getPool } from './_database';
+import { createHandler, parseJsonBody } from './_utils';
 
-export const handler: Handler = createHandler(async (event, context) => {
-  const jobId = event.queryStringParameters?.jobId;
-  const userId = event.queryStringParameters?.userId;
-  if (!jobId || !userId) {
-    throw { statusCode: 400, message: "Missing jobId or userId" };
+type DeletionPayload = {
+  jobId?: string;
+  userId?: string;
+};
+
+export const handler: Handler = createHandler(
+  ['POST'],
+  async (event, _context, { json, requestId }) => {
+    const payload = parseJsonBody<DeletionPayload>(event);
+    const jobId = payload.jobId;
+    const userId = payload.userId;
+
+    if (!jobId || !userId) {
+      return json(400, {
+        ok: false,
+        error: 'Missing jobId or userId',
+        requestId,
+      });
+    }
+
+    const pool = getPool();
+    const { rows } = await pool.query(
+      `SELECT id, status, source_key, processed_key, export_key, bucket, deletion_manifest
+       FROM jobs
+       WHERE id=$1 AND user_id=$2`,
+      [jobId, userId]
+    );
+
+    if (!rows.length) {
+      return json(404, {
+        ok: false,
+        error: 'Job not found',
+        requestId,
+      });
+    }
+
+    const job = rows[0] as Record<string, any>;
+    const bucket = job.bucket ?? 'default';
+
+    const calculatedArtifacts = [
+      job.source_key ? { type: 'incoming', key: job.source_key, bucket } : null,
+      job.processed_key ? { type: 'processed', key: job.processed_key, bucket } : null,
+      job.export_key ? { type: 'export', key: job.export_key, bucket } : null,
+    ].filter(Boolean) as Array<{ type: string; key: string; bucket: string }>;
+
+    let existingManifest = job.deletion_manifest;
+    if (typeof existingManifest === 'string') {
+      try {
+        existingManifest = JSON.parse(existingManifest);
+      } catch {
+        existingManifest = undefined;
+      }
+    }
+
+    if (existingManifest && typeof existingManifest !== 'object') {
+      existingManifest = undefined;
+    }
+
+    const manifestArtifacts =
+      existingManifest && typeof existingManifest === 'object' && Array.isArray(existingManifest.artifacts)
+        ? existingManifest.artifacts
+        : calculatedArtifacts;
+
+    const manifest = {
+      jobId,
+      userId,
+      status: 'PENDING',
+      requestedAt: new Date().toISOString(),
+      artifacts: manifestArtifacts,
+    };
+
+    await pool.query(
+      `UPDATE jobs
+       SET deletion_manifest = $3
+       WHERE id=$1 AND user_id=$2`,
+      [jobId, userId, manifest]
+    );
+
+    const status = typeof job.status === 'string' ? job.status.toLowerCase() : '';
+    if (status === 'processing' || status === 'queued') {
+      await pool.query('UPDATE jobs SET cancellation_requested=true WHERE id=$1', [jobId]);
+    }
+
+    return json(202, {
+      ok: true,
+      jobId,
+      status: manifest.status,
+      manifest,
+      requestId,
+    });
   }
-
-  const pool = getPool();
-  await pool.query(
-    "INSERT INTO deletion_manifests(job_id,user_id,status,artifacts) SELECT $1,$2,'PENDING',ARRAY[]::TEXT[] WHERE EXISTS(SELECT 1 FROM jobs WHERE id=$1 AND user_id=$2)",
-    [jobId, userId]
-  );
-
-  await pool.query("UPDATE jobs SET cancellation_requested=true WHERE id=$1 AND status='processing'", [jobId]);
-
-  return { message: "Deletion initiated", jobId };
-});
+);


### PR DESCRIPTION
## Summary
- export a shared JSON body parser and richer handler helper for Netlify functions, and update the delete-job endpoint to write manifests into jobs.deletion_manifest
- rework the delete-job endpoint to require POST JSON payloads, reuse existing manifests when present, and mark active jobs for cancellation
- point service layers at the existing database helper and correct the audit batcher upsert to target the idempotency key index while keeping job IDs as UUIDs end-to-end
- map the new audit, cost, and schedule SQLAlchemy models to the project Base with database-generated UUIDs so tables are created alongside existing metadata

## Testing
- pnpm --filter web build *(fails: npm registry blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68df04c5ca30832b9309452a76b2685e