### PR TITLE
Fix synchronous DB session usage in async services

### DIFF
--- a/apps/api/app/services/costs.py
+++ b/apps/api/app/services/costs.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import contextmanager
 from datetime import datetime, timezone, timedelta
 from typing import Optional, Dict, Any
 from uuid import UUID
@@ -9,37 +10,39 @@ from apps.api.app.config_t3 import settings
 
 log=logging.getLogger(__name__)
 
+
+def _db_session():
+    from apps.api.app.db import get_db_session
+
+    return contextmanager(get_db_session)()
+
 async def record_ocr_cost(job_id: UUID, user_id: Optional[str], provider:str, pages:int, cost_per_page_cents:int)->UUID:
     cost = pages*cost_per_page_cents
     if cost > settings.max_job_cost_cents: raise ValueError("Estimated OCR cost exceeds limit")
-    from apps.api.app.db import get_db_session
-    async with get_db_session() as s:
+    with _db_session() as s:
         rec = CostRecord(job_id=job_id,user_id=user_id,provider=provider,pages=pages,cost_cents=cost,status='PENDING',created_at=datetime.now(timezone.utc))
-        s.add(rec); await s.commit(); await s.refresh(rec)
+        s.add(rec); s.commit(); s.refresh(rec)
         return rec.id
 
 async def mark_cost_completed(record_id: UUID, success: bool=True):
-    from apps.api.app.db import get_db_session
-    async with get_db_session() as s:
-        res=await s.execute(select(CostRecord).where(CostRecord.id==record_id))
+    with _db_session() as s:
+        res=s.execute(select(CostRecord).where(CostRecord.id==record_id))
         rec=res.scalar_one_or_none()
         if rec:
             rec.status='COMPLETED' if success else 'FAILED'
-            rec.completed_at=datetime.now(timezone.utc); await s.commit()
+            rec.completed_at=datetime.now(timezone.utc); s.commit()
 
 async def get_user_costs(user_id: str)->Dict[str,Any]:
-    from apps.api.app.db import get_db_session
-    async with get_db_session() as s:
+    with _db_session() as s:
         stmt=select(func.sum(CostRecord.cost_cents).label('tc'), func.sum(CostRecord.pages).label('tp'), func.count(CostRecord.id).label('tj')).where(CostRecord.user_id==user_id, CostRecord.status=='COMPLETED')
-        row=(await s.execute(stmt)).one()
+        row=s.execute(stmt).one()
         tc=row.tc or 0
         return {'user_id':user_id,'total_cost_cents':tc,'total_cost_dollars':tc/100.0,'total_pages':row.tp or 0,'total_jobs':row.tj or 0}
 
 async def reconcile_costs()->Dict[str,Any]:
     cutoff=datetime.now(timezone.utc)-timedelta(minutes=5)
-    from apps.api.app.db import get_db_session
-    async with get_db_session() as s:
-        res=await s.execute(select(CostRecord).where(CostRecord.status=='PENDING', CostRecord.created_at < cutoff))
+    with _db_session() as s:
+        res=s.execute(select(CostRecord).where(CostRecord.status=='PENDING', CostRecord.created_at < cutoff))
         stale=res.scalars().all()
         div=[{'record_id':str(r.id),'job_id':str(r.job_id),'status':'STALE_PENDING','age_minutes':(datetime.now(timezone.utc)-r.created_at).total_seconds()/60} for r in stale]
         return {'divergences':div,'count':len(div)}


### PR DESCRIPTION
## Summary
- wrap the API service access to `get_db_session` in context manager helpers so they can use a synchronous SQLAlchemy session safely inside async code paths
- replace awaited SQLAlchemy calls with their synchronous counterparts across audit logging, cost tracking, GDPR cleanup, and job schedule export so database writes execute correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df09b522c0832bbbcf3dcc60610be1